### PR TITLE
Urlvalidation/malformed url fix

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -56,6 +56,7 @@ def is_valid(url, oldUrl = None):
     try:
         # if url does not contain http:// or https:// - maybe more exhaustive 
         # validation can be implemented
+		# source - https://gist.github.com/jarridlima/965022c848c37919664a47a83c034459
         if not re.match(r"^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$", url):
             return False
 

--- a/scraper.py
+++ b/scraper.py
@@ -54,6 +54,10 @@ def is_valid(url, oldUrl = None):
     # If you decide to crawl it, return True; otherwise return False.
     # There are already some conditions that return False.
     try:
+        # if url does not contain http:// or https://
+        if not re.match(r"((http|https)://)", url):
+            return False
+
         parsed = urlparse(url)
 
         if parsed.scheme not in {"http", "https"}:

--- a/scraper.py
+++ b/scraper.py
@@ -54,8 +54,9 @@ def is_valid(url, oldUrl = None):
     # If you decide to crawl it, return True; otherwise return False.
     # There are already some conditions that return False.
     try:
-        # if url does not contain http:// or https://
-        if not re.match(r"((http|https)://)", url):
+        # if url does not contain http:// or https:// - maybe more exhaustive 
+        # validation can be implemented
+        if not re.match(r"^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$", url):
             return False
 
         parsed = urlparse(url)


### PR DESCRIPTION
added regex to validate URL in `is_valid`. there were errors thrown from malformed URLs i.e. http:/uci.edu, the regex added prevents these URLs from being scraped by return False when `is_valid` is called on them.